### PR TITLE
Release v1.0.5: Fix session store crash (createSession not a function)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-02-25
+
+### Fixed
+- **Session Store Crash**: Fixed `TypeError: store.createSession is not a function` error that prevented sessions from working. SQLiteStore now correctly extends `express-session`'s `Store` base class instead of `EventEmitter`, providing the required `createSession` method.
+
 ## [1.0.4] - 2026-02-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bacalhau",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "description": "bacalhau - Self-hosted IPTV Player for NAS and Docker",
   "author": "Filipe Neves <me@filipeneves.net>",

--- a/transcoder/database.js
+++ b/transcoder/database.js
@@ -399,9 +399,9 @@ function deleteSetting(key) {
 
 // ==================== SESSION STORE FOR EXPRESS-SESSION ====================
 
-const { EventEmitter } = require('events');
+const session = require('express-session');
 
-class SQLiteStore extends EventEmitter {
+class SQLiteStore extends session.Store {
     constructor() {
         super();
         this.db = getDatabase();


### PR DESCRIPTION
This pull request addresses a critical bug in the session management system that was causing crashes due to an incorrect class inheritance in the custom session store. The main focus is on ensuring compatibility with `express-session` by properly extending its `Store` base class, which resolves the missing method error. The package version and changelog have also been updated accordingly.

**Bug Fixes and Maintenance:**

* Fixed a session store crash (`TypeError: store.createSession is not a function`) by updating `SQLiteStore` to extend `express-session`'s `Store` base class instead of `EventEmitter`, ensuring the required methods are available.
* Updated the project version to `1.0.5` in `package.json` to reflect the bug fix.
* Added a new entry to `CHANGELOG.md` documenting the session store crash fix in version `1.0.5`.