### PR TITLE
Faster live stream startup (~8s → ~3s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-07-02
+
+### Improved
+- **Faster Stream Startup**: Cut the wait before a live stream begins playing from ~8s to ~3s
+  - Low-latency FFmpeg input options for live streams (`-fflags nobuffer`, `-flags low_delay`, reduced `-analyzeduration`/`-probesize`) cut source probing from ~5s to under 1s
+  - Live HLS segment duration reduced from 4s to 2s so playable segments are produced sooner (VOD keeps 4s segments for efficient seeking)
+  - Forced keyframes at each segment boundary let FFmpeg cut segments exactly on time instead of waiting for the source's next keyframe
+  - Server now responds as soon as the playlist lists 2 finalized segments (previously waited for 3), and counts actual playlist entries instead of on-disk `.ts` files — the latter could include a half-written segment and hand the client an unplayable playlist
+  - Readiness polling interval tightened from 500ms to 50ms so playback starts the instant segments land
+  - Player no longer uses `lowLatencyMode` for live playback (it hugged the live edge and started with no buffer, causing `bufferStalledError` and a slow, nudgy start); it now begins a couple of segments back on already-buffered data for an immediate, stall-free start
+
+### Developer
+- **Transcoder Hot Reload**: Added `docker-compose.override.yml` that bind-mounts the transcoder source and runs it under `node --watch`, so `transcoder/server.js` changes restart the process in-place with no image rebuild (a named volume preserves the image's compiled `better-sqlite3`)
+- **Startup Timing Logs**: The transcoder logs `[Timing]` markers (spawn → input probed → encoding started → segments ready → responded) to make time-to-first-frame regressions easy to diagnose
+
 ## [1.2.0] - 2026-04-01
 
 ### Added

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,26 @@
+# Local development overrides — Docker Compose merges this file automatically
+# on top of docker-compose.yml for every `docker compose` command in this dir.
+#
+# Purpose: hot reload for the transcoder. Editing transcoder/server.js (or
+# database.js / migrate.js) restarts the Node process in-place via `node --watch`
+# with NO image rebuild.
+#
+# How it works:
+#   - ./transcoder is bind-mounted into /app so the container sees your edits live.
+#   - The `transcoder_node_modules` named volume is layered over /app/node_modules
+#     so the bind mount does NOT shadow the image's compiled deps. This matters
+#     because better-sqlite3 is a native module built during `docker build`; using
+#     the host's (nonexistent / mismatched) node_modules would crash the process.
+#     Docker seeds this named volume from the image the first time it's created.
+#
+# To temporarily run WITHOUT hot reload (e.g. to mimic production), rename this
+# file or pass: docker compose -f docker-compose.yml up transcoder
+services:
+  transcoder:
+    volumes:
+      - ./transcoder:/app:z
+      - transcoder_node_modules:/app/node_modules
+    command: ["node", "--watch", "server.js"]
+
+volumes:
+  transcoder_node_modules:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bacalhau",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bacalhau",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@mdi/font": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bacalhau",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "bacalhau - Self-hosted IPTV Player for NAS and Docker",
   "author": "Filipe Neves <me@filipeneves.net>",

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -569,10 +569,13 @@ export default {
                     
                     hlsInstance = new Hls({
                         enableWorker: true,
-                        lowLatencyMode: true,              // Faster start for live streams
+                        // Off: lowLatencyMode hugs the live edge and starts with almost
+                        // no buffer, causing bufferStalledError and a slow, nudgy start.
+                        // Starting a couple segments back begins on buffered data instead.
+                        lowLatencyMode: false,
                         backBufferLength: 30,
-                        liveSyncDurationCount: 2,          // Start after 2 segments (was 3)
-                        liveMaxLatencyDurationCount: 4,    // Tighter latency window
+                        liveSyncDurationCount: 2,          // Start 2 segments behind the edge
+                        liveMaxLatencyDurationCount: 6,    // Room before latency-catchup kicks in
                         maxBufferLength: 10,               // Smaller initial buffer target
                         maxMaxBufferLength: 30,
                         maxBufferHole: 0.5,
@@ -683,7 +686,11 @@ export default {
                         console.log('Playing transcoded HLS stream, isVod:', isVod);
                         const hlsConfig = {
                             enableWorker: true,
-                            lowLatencyMode: !isVod,
+                            // lowLatencyMode makes hls.js hug the live edge, which on a
+                            // regular (non-LL-HLS) transcoded stream means starting with
+                            // almost no buffer → bufferStalledError and a slow, nudgy start.
+                            // Off = start a few segments back with a solid buffer instead.
+                            lowLatencyMode: false,
                             backBufferLength: 30,
                             maxBufferLength: 10,
                             maxMaxBufferLength: 30,
@@ -694,8 +701,12 @@ export default {
                             preferManagedMediaSource: false
                         };
                         if (!isVod) {
-                            hlsConfig.liveSyncDurationCount = 2;
-                            hlsConfig.liveMaxLatencyDurationCount = 4;
+                            // Start 3 short (2s) segments behind the live edge so there's
+                            // always buffered runway to begin playback immediately. ~6s
+                            // behind live is imperceptible for IPTV and eliminates the
+                            // initial stall that was costing several seconds of startup.
+                            hlsConfig.liveSyncDurationCount = 3;
+                            hlsConfig.liveMaxLatencyDurationCount = 10;
                         }
                         hlsInstance = new Hls(hlsConfig);
                         // IMPORTANT: attachMedia FIRST, then loadSource after MEDIA_ATTACHED

--- a/transcoder/server.js
+++ b/transcoder/server.js
@@ -217,11 +217,24 @@ function buildFFmpegArgs({ streamUrl, hwAccel, hwDecode, preset, quality, stream
             break;
     }
     
+    // Low-latency input options for live streams: minimize the time FFmpeg
+    // spends probing the source before it starts producing output. The defaults
+    // (analyzeduration/probesize ~5s / 5MB) can add several seconds to startup.
+    // MPEG-TS from IPTV providers carries PAT/PMT early, so a small probe is enough.
+    if (!isVod) {
+        args.push(
+            '-fflags', 'nobuffer',
+            '-flags', 'low_delay',
+            '-analyzeduration', '1000000',  // 1s (microseconds)
+            '-probesize', '2000000'         // 2MB
+        );
+    }
+
     // Common input options
     args.push(
         '-i', streamUrl
     );
-    
+
     // Reconnect options only for live streams, not VOD
     if (!isVod) {
         // Insert reconnect options before -i
@@ -349,11 +362,23 @@ function buildFFmpegArgs({ streamUrl, hwAccel, hwDecode, preset, quality, stream
             '-ac', '2'
         );
     }
-    // HLS output options differ for live vs VOD
+    // HLS output options differ for live vs VOD.
+    // Live uses short 2s segments so the very first segment is ready quickly,
+    // dramatically cutting the time-to-first-frame. VOD keeps 4s segments since
+    // startup latency matters less and larger segments seek more efficiently.
+    const segmentDuration = isVod ? 4 : 2;
+
+    // Force a keyframe at every segment boundary so the HLS muxer can cut a
+    // segment exactly at `segmentDuration` instead of waiting for the source's
+    // next keyframe (which may be many seconds away). Not possible in copy mode.
+    if (hwAccel !== 'none') {
+        args.push('-force_key_frames', `expr:gte(t,n_forced*${segmentDuration})`);
+    }
+
     if (isVod) {
         args.push(
             '-f', 'hls',
-            '-hls_time', '4',
+            '-hls_time', String(segmentDuration),
             '-hls_list_size', '0',
             '-hls_playlist_type', 'event',
             '-hls_flags', 'independent_segments',
@@ -364,7 +389,7 @@ function buildFFmpegArgs({ streamUrl, hwAccel, hwDecode, preset, quality, stream
     } else {
         args.push(
             '-f', 'hls',
-            '-hls_time', '4',
+            '-hls_time', String(segmentDuration),
             '-hls_list_size', '10',
             '-hls_flags', 'delete_segments+append_list+independent_segments',
             '-hls_segment_filename', path.join(streamDir, 'segment%03d.ts'),
@@ -443,9 +468,20 @@ app.get('/transcode', requireAuth, async (req, res) => {
     console.log(`[Transcoder] Starting FFmpeg for stream ${streamId}`);
     console.log(`[Transcoder] FFmpeg args: ffmpeg ${ffmpegArgs.join(' ')}`);
 
+    // Startup timing instrumentation — logs where the time-to-first-frame goes:
+    //   input open  = FFmpeg connecting to + probing the upstream source
+    //   first frame = FFmpeg finished probing and began producing output
+    //   1st segment = first .ts segment finalized on disk (realtime encode)
+    //   responded   = handler returns the stream URL to the client
+    const t0 = Date.now();
+    const since = () => `${Date.now() - t0}ms`;
+    let loggedInputOpen = false;
+    let loggedFirstFrame = false;
+
     const ffmpeg = spawn('ffmpeg', ffmpegArgs, {
         stdio: ['ignore', 'pipe', 'pipe']
     });
+    console.log(`[Timing ${streamId}] ffmpeg spawned at +${since()}`);
 
     let ffmpegOutput = '';
 
@@ -457,6 +493,15 @@ app.get('/transcode', requireAuth, async (req, res) => {
         ffmpegOutput += data.toString();
         // Log only important messages
         const msg = data.toString();
+        // Timing: first sign the input opened, and first sign output started
+        if (!loggedInputOpen && (msg.includes('Input #0') || msg.includes('Stream mapping'))) {
+            loggedInputOpen = true;
+            console.log(`[Timing ${streamId}] input opened + probed at +${since()}`);
+        }
+        if (!loggedFirstFrame && (msg.includes('Output #0') || msg.includes('frame='))) {
+            loggedFirstFrame = true;
+            console.log(`[Timing ${streamId}] output/encoding started at +${since()}`);
+        }
         if (msg.includes('Error') || msg.includes('error') || msg.includes('Opening') || msg.includes('Stream')) {
             console.log(`[FFmpeg ${streamId}] ${msg.trim()}`);
         }
@@ -481,19 +526,41 @@ app.get('/transcode', requireAuth, async (req, res) => {
         startTime: Date.now()
     });
 
-    // Wait for playlist to be created and have at least 3 segments (with timeout)
+    // Wait for the playlist and the first segment(s), then respond as early as
+    // possible. Previously this waited for 3 segments (up to 12s of encoded video
+    // with 4s segments) before returning — the main source of startup latency.
+    // With 2s live segments, one ready segment is enough for hls.js to begin, and
+    // FFmpeg keeps producing more while the client sets up. Poll frequently (50ms)
+    // so we return the instant the segment lands rather than up to 500ms late.
     const maxWait = 20000; // 20 seconds
-    const checkInterval = 500;
+    const checkInterval = 50;
+    // Respond once TWO finalized segments are listed. One segment lets the client
+    // start before FFmpeg has buffered any runway, so playback catches the encoder
+    // and stalls (bufferStalledError); two segments give hls.js enough to begin
+    // smoothly while FFmpeg stays ahead.
+    const minSegments = 2;
     let waited = 0;
 
     const waitForPlaylist = () => {
         return new Promise((resolve, reject) => {
             const check = () => {
                 if (fs.existsSync(playlistPath)) {
-                    // Check if we have at least 3 segments for smooth playback
-                    const segments = fs.readdirSync(streamDir)
-                        .filter(f => f.startsWith('segment') && f.endsWith('.ts'));
-                    if (segments.length >= 3) {
+                    // Count segments actually LISTED in the playlist (#EXTINF), not
+                    // .ts files on disk — a segment file exists the moment FFmpeg
+                    // starts writing it, but it isn't playable (or in the playlist)
+                    // until finalized. Responding on the disk-file count could hand
+                    // the client a playlist with no playable segment yet, causing a
+                    // bufferStalledError. Two finalized segments give hls.js enough
+                    // runway to start smoothly.
+                    let readySegments = 0;
+                    try {
+                        const playlist = fs.readFileSync(playlistPath, 'utf8');
+                        readySegments = (playlist.match(/#EXTINF/g) || []).length;
+                    } catch (e) {
+                        // playlist mid-write; try again next tick
+                    }
+                    if (readySegments >= minSegments) {
+                        console.log(`[Timing ${streamId}] ${readySegments} segment(s) in playlist at +${since()}`);
                         resolve(true);
                     } else if (waited >= maxWait) {
                         // If timeout but playlist exists, go ahead anyway
@@ -517,6 +584,7 @@ app.get('/transcode', requireAuth, async (req, res) => {
 
     try {
         await waitForPlaylist();
+        console.log(`[Timing ${streamId}] responding to client at +${since()}`);
         console.log(`[Transcoder] HLS playlist ready for stream ${streamId}`);
 
         res.json({


### PR DESCRIPTION
Server (transcoder/server.js):
- Low-latency input flags for live: -fflags nobuffer, -flags low_delay, reduced -analyzeduration/-probesize (source probe ~5s → <1s)
- 2s live HLS segments (VOD stays 4s), forced keyframes at segment boundaries so FFmpeg cuts on time instead of waiting for source keyframes
- Respond once the playlist lists 2 finalized segments; count #EXTINF entries instead of on-disk .ts files (avoids handing the client a half-written, unplayable playlist)
- Tightened readiness polling 500ms → 50ms
- Added [Timing] startup instrumentation

Client (VideoPlayer.vue):
- Disable lowLatencyMode for live on both transcoded and direct-HLS paths; start a couple segments behind the edge on buffered data to eliminate the initial bufferStalledError and slow nudgy start

Dev:
- docker-compose.override.yml: transcoder hot reload via node --watch, with a named volume preserving the image's compiled better-sqlite3